### PR TITLE
port fix in serialize.h in order to have miner working with OSX devices

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -895,19 +895,6 @@ public:
     iterator insert(iterator it, const char& x=char()) { return vch.insert(it, x); }
     void insert(iterator it, size_type n, const char& x) { vch.insert(it, n, x); }
 
-    void insert(iterator it, const_iterator first, const_iterator last)
-    {
-        assert(last - first >= 0);
-        if (it == vch.begin() + nReadPos && (unsigned int)(last - first) <= nReadPos)
-        {
-            // special case for inserting at the front when there's room
-            nReadPos -= (last - first);
-            memcpy(&vch[nReadPos], &first[0], last - first);
-        }
-        else
-            vch.insert(it, first, last);
-    }
-
     void insert(iterator it, std::vector<char>::const_iterator first, std::vector<char>::const_iterator last)
     {
         assert(last - first >= 0);


### PR DESCRIPTION
I ported a previous published patch for bit coin in order to allow osx devices to be able to compile it, in order to have it working I had to remove the first declaration of insert function in serializer.h.
