### PR TITLE
MinGW 4.8.1 Compilation Fix

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1668,7 +1668,11 @@ bool BindListenPort(const CService &addrBind, string& strError)
     // and enable it by default or not. Try to enable it, if possible.
     if (addrBind.IsIPv6()) {
 #ifdef IPV6_V6ONLY
+#ifdef WIN32
+        setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (const char*)&nOne, sizeof(int));
+#else
         setsockopt(hListenSocket, IPPROTO_IPV6, IPV6_V6ONLY, (void*)&nOne, sizeof(int));
+#endif
 #endif
 #ifdef WIN32
         int nProtLevel = 10 /* PROTECTION_LEVEL_UNRESTRICTED */;


### PR DESCRIPTION
fix invalid conversion error with MinGW 4.8.1 in net.cpp

Bitcoin compilation bug also fixed at https://github.com/bitcoin/bitcoin/commit/6c6255edb54bed780f0879c906dccf6cfa98b4db
